### PR TITLE
[tutorials] Remove language indicators to proper rendering

### DIFF
--- a/tutorials/cpp/index.md
+++ b/tutorials/cpp/index.md
@@ -119,7 +119,7 @@ understand everything you can do in the `.proto` file.
 
 In this tutorial our `src/service_spec/tutorial.proto` will be like this:
 
-```Java
+```
 syntax = "proto3";
 
 package tutorial;
@@ -153,7 +153,7 @@ In order to actually implement our API we need to edit `src/server.cc`.
 Look for `PROTO_TYPES` and replace the `using` statements to reflect our data
 types defined in step 3.
 
-```C++
+```
 using tutorial::ServiceDefinition;
 using tutorial::IntPair;
 using tutorial::SingleInt;
@@ -162,7 +162,7 @@ using tutorial::SingleString;
 
 Now look for `SERVICE_API` and replace `doSomething()` by our actual API methods:
 
-```C++
+```
 Status div(ServerContext* context, const IntPair* input, SingleInt* output) override {
     output->set_v(input->a() / input->b());
     return Status::OK;
@@ -185,7 +185,7 @@ blockchain). Edit `src/client.cc`.
 Look for `PROTO_TYPES` and replace the `using` statements to reflect our data
 types defined in Step 3.
 
-```C++
+```
 using tutorial::ServiceDefinition;
 using tutorial::IntPair;
 using tutorial::SingleInt;
@@ -196,7 +196,7 @@ Now look for `TEST_CODE` and replace `doSomething()` implementation by our
 testing code:
 
 
-```C++
+```
 void doSomething(int argc, char** argv) {
 
     int n1 = atoi(argv[1]);

--- a/tutorials/go/index.md
+++ b/tutorials/go/index.md
@@ -108,7 +108,7 @@ understand everything you can do in the `.proto` file.
 
 In this tutorial our `./service_spec/tutorial.proto` will be like this:
 
-```Java
+```
 syntax = "proto3";
 
 package tutorial;
@@ -141,7 +141,7 @@ In order to actually implement our API we need to edit `server.go`.
 
 Look for `SERVICE_API` and replace `doSomething()` by our actual API methods:
 
-```Go
+```
 func (s *server) Div(ctx context.Context, in *pb.IntPair) (*pb.SingleInt, error) {
 	return &pb.SingleInt{V: in.A / in.B}, nil
 }
@@ -158,7 +158,7 @@ Look for `TEST_CODE` and replace `doSomething()` implementation by our
 testing code:
 
 
-```Go
+```
 func doSomething(conn *grpc.ClientConn) (*pb.SingleInt, error) {
 	// Check the compiled proto file (.pb.go) to get this method name
 	c := pb.NewServiceDefinitionClient(conn)

--- a/tutorials/java/index.md
+++ b/tutorials/java/index.md
@@ -107,13 +107,13 @@ Take a look at https://developers.google.com/protocol-buffers/docs/overview to
 understand everything you can do in the `.proto` file.
 
 Edit the proto file:
-```Java
+```
 # nano src/main/java/service_spec/tutorial.proto
 ```
 
 In this tutorial our proto file should be like this:
 
-```Java
+```
 syntax = "proto3";
 
 option java_generic_services = true;
@@ -147,7 +147,7 @@ In order to actually implement our API we need to edit the `JavaServer.java file
 
 Look for `SERVICE_API` and replace `doSomething()` by our actual API methods:
 
-```Java
+```
 
 @Override
 public void div(IntPair request, StreamObserver<SingleInt> responseObserver) {
@@ -167,7 +167,7 @@ Look for `TEST_CODE` and replace `doSomething()` implementation by our
 testing code:
 
 
-```Java
+```
 public void div(int a, int b) {
     logger.info("Trying to divide "+a+" by "+ b);
     IntPair request = IntPair.newBuilder().setA(a).setB(b).build();

--- a/tutorials/python/index.md
+++ b/tutorials/python/index.md
@@ -108,7 +108,7 @@ understand everything you can do in the `.proto` file.
 
 In this tutorial our `./service_spec/tutorial.proto` will be like this:
 
-```Java
+```
 syntax = "proto3";
 
 package tutorial;
@@ -141,7 +141,7 @@ In order to actually implement our API we need to edit `server.py`.
 
 Look for `SERVICE_API` and replace `doSomething()` by our actual API methods:
 
-```Python
+```
 class ServiceDefinition(pb2_grpc.ServiceDefinitionServicer):
     def __init__(self):
         self.a = 0
@@ -168,7 +168,7 @@ blockchain). Edit `client.py`.
 Look for `TEST_CODE` and replace `doSomething()` implementation by our
 testing code:
 
-```Python
+```
 def doSomething(channel):
     a = 12
     b = 4


### PR DESCRIPTION
The current theme seems to not proper render code when user specify a language.
I'm looking for a solution, but right now, to keep the tutorials consistent I decided to remove all language indicators.