### PR TITLE
[publish] Leaner tutorial and Reqs page.

### DIFF
--- a/tutorials/requirements/index.md
+++ b/tutorials/requirements/index.md
@@ -1,0 +1,82 @@
+﻿---
+# Page settings
+layout: default
+keywords:
+comments: true
+
+# Hero section
+title: System Requirements to Publish a SingularityNET Service
+description: Getting your system ready
+
+# extralink box
+extralink:
+    title: All Docs
+    title_url: '/docs/all'
+    external_url: false
+    description: Find an overview of our full documentation here.
+
+# Developer Newsletter
+dev_news: true
+
+# Micro navigation
+micro_nav: true
+
+# Page navigation
+page_nav:
+    prev:
+        content: Back to tutorials
+        url: '/tutorials/publish'
+    next:
+        content: View all docs
+        url: '/docs/all'
+---
+
+[naming-standards]: https://dev.singularitynet.io/docs/all/naming-standard/
+
+## Step 1a. Setup your system
+
+#### Requirements
+
+- [Python 3.6+](https://www.python.org/downloads/)
+- [Node 8+ with npm](https://nodejs.org/en/download/)
+- [SNET CLI](https://github.com/singnet/snet-cli/releases)
+    - libudev
+    - libusb 1.0
+- [SNET Daemon](https://github.com/singnet/snet-daemon/releases)
+
+For example, installing the requirements using `Ubuntu 18.04`:
+
+```
+sudo apt-get update
+sudo apt-get install wget git
+sudo apt-get install python3 python3-pip
+sudo apt-get install nodejs npm
+sudo apt-get install libudev-dev libusb-1.0-0-dev
+sudo pip3 install snet-cli
+
+# !!! Change version to the latest snet-daemon from releases link above
+SNETD_VERSION="v0.1.6"
+
+wget https://github.com/singnet/snet-daemon/releases/download/$SNETD_VERSION/snetd-linux-amd64
+chmod a+x snetd-linux-amd64
+sudo mv snetd-linux-amd64 /usr/bin/snetd
+```
+
+Setup environment variables (they are explained later in this tutorial as they're used):
+
+```
+ORGANIZATION_ID="$USER"-org
+ORGANIZATION_NAME="The $USER's Organization"
+
+SERVICE_ID=example-service
+SERVICE_NAME="SNET Example Service"
+SERVICE_IP=127.0.0.1
+SERVICE_PORT=7000
+
+DAEMON_HOST=$SERVICE_IP
+DAEMON_PORT=$SERVICE_PORT
+
+USER_ID = $USER
+```
+
+After installation, you can proceed with [Tutorial/Publish/Step3](https://dev.singularitynet.io/tutorials/publish/#step-3-setup-snet-cli-and-create-your-identity).


### PR DESCRIPTION
All changes were made to turn the Publish Tutorial more lean.
Now user can just copy & past the commands to get the service published and running.
I've added a new page (`tutorials/requirements`) where I show the System Requirements and and example of installation when running the tutorial on Ubuntu 18.04.