### PR TITLE
[SDP-63] Replace deprecated COG terminology with AFET and update token precision

### DIFF
--- a/docs/products/DecentralizedAIPlatform/CLI/Manual/Client/index.md
+++ b/docs/products/DecentralizedAIPlatform/CLI/Manual/Client/index.md
@@ -177,7 +177,7 @@ Nonce of the channel
 
     
 
-Amount in cogs
+Amount in AFET
 
 `METHOD`
 

--- a/docs/products/DecentralizedAIPlatform/CoreConcepts/SmartContracts/mpe/index.md
+++ b/docs/products/DecentralizedAIPlatform/CoreConcepts/SmartContracts/mpe/index.md
@@ -61,7 +61,7 @@ If Kevin is buying services from Jack, they both need to enter in to a formal ag
 
 3. **Kevin funds the channel.** Kevin suggests Jack to deposit a bare amount (cost of the service) and mentions that the amount can never been withdrawn for a predetermined period of time. This period is configurable.
    
-   Based on how much Jack wants to use a service, Jack deposits the amount in to the channel accordingly, so if the cost is 1 cog, and Jack needs to use it 10 times, he will deposit 10 cogs. Nonce is always zero when you create the channel for the first time.
+   Based on how much Jack wants to use a service, Jack deposits the amount in to the channel accordingly, so if the cost is 1 AFET, and Jack needs to use it 10 times, he will deposit 10 AFET. Nonce is always zero when you create the channel for the first time.
    
    **Note:** Unless and until Jack authorises, Kevin cannot withdraw the money. Kevin and Jack come in to agreement to perform operation Off chain. The daemon manages the off chain state of the channel.
 
@@ -93,7 +93,7 @@ Kevin (Buyer) and Jack (Service provider) enter into a contract for the first ti
 |-----------|-------|-------------|
 | **Channel ID** | 1 | The channel ID created is 1 on Chain |
 | **Nonce** | 0 | Initially the Nonce is 0 |
-| **Full amount** | 100 Cogs | Amount Kevin has put into the channel is 100 Cogs |
+| **Full amount** | 100 AFET | Amount Kevin has put into the channel is 100 AFET |
 | **Authorized Amount** | 0 | The Authorized amount is zero, because no services has been used for the first time |
 | **Signature** | Nil | No signature is required to be sent |
 
@@ -101,29 +101,29 @@ Kevin (Buyer) and Jack (Service provider) enter into a contract for the first ti
 
 ### First Service Call
 
-Kevin makes a call and authorizes for 1 cog to Kevin, (assuming the cost of the service is 1 cog), the status of the channel is now maintained offchain by the storage mechanism used by Daemon:
+Kevin makes a call and authorizes for 1 AFET to Kevin, (assuming the cost of the service is 1 AFET), the status of the channel is now maintained offchain by the storage mechanism used by Daemon:
 
 | Parameter | Value | Description |
 |-----------|-------|-------------|
 | **Channel ID** | 1 | The channel ID 1 is now updated off chain |
 | **Nonce** | 0 | Initially the Nonce is 0 |
-| **Full amount** | 100 Cogs | Amount Kevin has put into the channel is 100 Cogs |
-| **Authorized Amount** | 1 | The Authorized amount is one cog |
-| **Signature** | 1 | Signature is required for one cog |
+| **Full amount** | 100 AFET | Amount Kevin has put into the channel is 100 AFET |
+| **Authorized Amount** | 1 | The Authorized amount is one AFET |
+| **Signature** | 1 | Signature is required for one AFET |
 
 ---
 
 ### Second Service Call
 
-Kevin makes a call and authorizes for 2 cogs to Kevin, now the status changes as follows:
+Kevin makes a call and authorizes for 2 AFET to Kevin, now the status changes as follows:
 
 | Parameter | Value | Description |
 |-----------|-------|-------------|
 | **Channel ID** | 1 | The channel ID 1 is now updated off chain |
 | **Nonce** | 0 | Initially the Nonce is 0 |
-| **Full amount** | 100 Cogs | Amount Kevin has put into the channel is 100 Cogs |
-| **Authorized Amount** | 2 Cogs | The Authorized amount is two |
-| **Signature** | 2 Cogs | Signature is required for two |
+| **Full amount** | 100 AFET | Amount Kevin has put into the channel is 100 AFET |
+| **Authorized Amount** | 2 AFET | The Authorized amount is two |
+| **Signature** | 2 AFET | Signature is required for two |
 
 ---
 
@@ -135,13 +135,13 @@ Jack makes a claim using the signature from Jack, this transaction is considered
 |-----------|-------|-------------|
 | **Channel ID** | 1 | The channel ID created is 1 |
 | **Nonce** | 1 | Initially the Nonce was 0 but now it is 1 |
-| **Full amount** | 98 Cogs | Amount signed by Jack was for two cogs. The full amount in the channel is 98 |
+| **Full amount** | 98 AFET | Amount signed by Jack was for two AFET. The full amount in the channel is 98 |
 | **Authorized Amount** | 0 | The Authorized amount is zero after claim |
 | **Signature** | 0 | No signature is required to be sent |
 
 **Note:** Claims are always on-chain transaction and the Nonce gets incremented when claims are made.
 
-The same process follows for future calls authorizations of cogs.
+The same process follows for future calls authorizations of AFET.
 
 ## Channel Management Functions
 

--- a/docs/products/DecentralizedAIPlatform/CoreConcepts/asi-token/index.md
+++ b/docs/products/DecentralizedAIPlatform/CoreConcepts/asi-token/index.md
@@ -23,7 +23,7 @@ We have an automated faucet for distributing Sepolia Testnet ASI Tokens [here](h
 
 Symbol: ASI
 
-Decimals: 8
+Decimals: 18
 
 Sepolia Token Address: 
 [0x3A54192862D1c52C8175d4912f1f778d1E3C2449](https://sepolia.etherscan.io/address/0x3A54192862D1c52C8175d4912f1f778d1E3C2449)

--- a/docs/products/DecentralizedAIPlatform/CoreConcepts/glossary/index.md
+++ b/docs/products/DecentralizedAIPlatform/CoreConcepts/glossary/index.md
@@ -119,9 +119,9 @@ ASI (FET) is the native utility token of the SingularityNET platform:
 
 ---
 
-### COGS
+### AFET
 
-COGS are the smallest unit of measurement for transactions on the platform, similar to how wei relates to Ether. Service pricing and payments are calculated in COGS.
+AFET is the smallest unit of measurement for ASI (FET) token transactions on the platform, similar to how wei relates to Ether (1 FET = 10^18 AFET). Service pricing and payments are calculated in AFET.
 
 ---
 

--- a/docs/products/DecentralizedAIPlatform/DevelopersTutorials/FullGuideOnboarding/index.md
+++ b/docs/products/DecentralizedAIPlatform/DevelopersTutorials/FullGuideOnboarding/index.md
@@ -873,7 +873,7 @@ Where:
 - `SERVICE_DISPLAY_NAME`: User-friendly name for your service (can be any name)
 - `PAYMENT_GROUP_NAME`: The group name you defined earlier during [organization setup](#step-4-add-recipient-and-group-details)
 - `DAEMON_ENDPOINT`: Public endpoint (domain or IP address with port) of your deployed daemon
-- `FIXED_PRICE`: Price per service call in ASI (FET) (for example, `0.00000001` ASI (FET) = 1 COG)
+- `FIXED_PRICE`: Price per service call in ASI (FET) (for example, `0.000000000000000001` ASI (FET) = 1 AFET)
 - `SERVICE_TYPE`: Choose the service type you defined at the very beginning of this guide (`grpc` or `http`)
 
 **Example:**

--- a/docs/products/DecentralizedAIPlatform/DevelopersTutorials/IntegrationTrainingService/index.md
+++ b/docs/products/DecentralizedAIPlatform/DevelopersTutorials/IntegrationTrainingService/index.md
@@ -4,7 +4,7 @@ This guide will help you maintain training for your service.
 
 The AI developer needs to implement 8 methods for daemon <a href="/assets/files/training.proto" download>training.proto</a>  
 
-Most of the methods are free, but the methods for validation and training are paid, the price for them can be found through validate_model_price & train_model_price. As a service provider, you must implement the logic of calculating the price for these two methods. You can always return 1 cog or make dynamic logic depending on the parameters and dataset.
+Most of the methods are free, but the methods for validation and training are paid, the price for them can be found through validate_model_price & train_model_price. As a service provider, you must implement the logic of calculating the price for these two methods. You can always return 1 AFET or make dynamic logic depending on the parameters and dataset.
 
 AI consumer will call all these methods:
 
@@ -162,11 +162,11 @@ AI consumer will call all these methods:
 
     def validate_model_price(self, request, context):
         print(request.training_data_link)
-        return training_pb2.PriceInBaseUnit(price=1)  # 1 cog
+        return training_pb2.PriceInBaseUnit(price=1)  # 1 AFET
 
     def train_model_price(self, request, context):
         model_id = request.model_id.model_id
-        return training_pb2.PriceInBaseUnit(price=1)  # 1 cog
+        return training_pb2.PriceInBaseUnit(price=1)  # 1 AFET
 
     def train_model(self, request, context):
         model_id = request.model_id.model_id

--- a/docs/products/DecentralizedAIPlatform/DevelopersTutorials/OnboardingViaCLI/index.md
+++ b/docs/products/DecentralizedAIPlatform/DevelopersTutorials/OnboardingViaCLI/index.md
@@ -296,8 +296,8 @@ Where,
 - `SERVICE_DISPLAY_NAME` - Display name of your service. You can choose any name you want.
 - `PAYMENT_GROUP_NAME` - Name of the payment group from organization metadata published in organization setup, step 4
 - `DAEMON_ENDPOINT` - Endpoint which will be used to connect to your service daemon.
-- `FIXED_PRICE` - Price in ASI (FET) for a single call to your service. We will set the price to `10^-8 ASI (FET)` \
-(remember that `10^-8 ASI (FET) = 1 COG`).
+- `FIXED_PRICE` - Price in ASI (FET) for a single call to your service. We will set the price to `10^-18 ASI (FET)` \
+(remember that `10^-18 ASI (FET) = 1 AFET`).
 
 Example: 
 

--- a/docs/products/DecentralizedAIPlatform/SDK/PythonSDK/Documentation/account/index.md
+++ b/docs/products/DecentralizedAIPlatform/SDK/PythonSDK/Documentation/account/index.md
@@ -173,15 +173,15 @@ Retrieves the escrow balance for the current account.
 
 ##### returns:
 
-- The escrow balance in cogs. (int)
+- The escrow balance in AFET. (int)
 
 ### `deposit_to_escrow_account`
 
-Deposit the specified amount of ASI (FET) tokens in cogs into the MPE account.
+Deposit the specified amount of ASI (FET) tokens in AFET into the MPE account.
 
 ##### args:
 
-- `amount_in_cogs` (int): The amount of ASI (FET) tokens in cogs to deposit.
+- `amount_in_afet` (int): The amount of ASI (FET) tokens in AFET to deposit.
 
 ##### returns:
 
@@ -189,11 +189,11 @@ Deposit the specified amount of ASI (FET) tokens in cogs into the MPE account.
 
 ### `approve_transfer`
 
-Approves a transfer of a specified amount of ASI (FET) tokens in cogs to the MPE contract.
+Approves a transfer of a specified amount of ASI (FET) tokens in AFET to the MPE contract.
 
 ##### args:
 
-- `amount_in_cogs` (int): The amount of ASI (FET) tokens in cogs to approve for transfer.
+- `amount_in_afet` (int): The amount of ASI (FET) tokens in AFET to approve for transfer.
 
 ##### returns:
 
@@ -205,5 +205,5 @@ Retrieves the allowance of the current account for the MPE contract.
 
 ##### returns:
 
-- The allowance in cogs. (int)
+- The allowance in AFET. (int)
 

--- a/docs/products/DecentralizedAIPlatform/SDK/PythonSDK/Documentation/mpe-contract/index.md
+++ b/docs/products/DecentralizedAIPlatform/SDK/PythonSDK/Documentation/mpe-contract/index.md
@@ -51,7 +51,7 @@ If no contract address is provided, it uses the default MultiPartyEscrow contrac
 
 ### `balance`
 
-Returns the balance of the given address in the MPE contract in cogs.
+Returns the balance of the given address in the MPE contract in AFET.
 
 ##### args:
 
@@ -59,16 +59,16 @@ Returns the balance of the given address in the MPE contract in cogs.
 
 ##### returns:
 
-- The balance in cogs. (int)
+- The balance in AFET. (int)
 
 ### `deposit`
 
-Deposit the specified amount of ASI (FET) tokens in cogs into the MultiPartyEscrow contract.
+Deposit the specified amount of ASI (FET) tokens in AFET into the MultiPartyEscrow contract.
 
 ##### args:
 
 - `account` (Account): The account instance used to send the transaction.
-- `amount_in_cogs` (int): The amount of ASI (FET) tokens in cogs to deposit.
+- `amount_in_afet` (int): The amount of ASI (FET) tokens in AFET to deposit.
 
 
 ##### returns:
@@ -77,14 +77,14 @@ Deposit the specified amount of ASI (FET) tokens in cogs into the MultiPartyEscr
 
 ### `open_channel`
 
-Opens a payment channel with the specified amount of ASI (FET) tokens in cogs (taken from MPE) and expiration time.
+Opens a payment channel with the specified amount of ASI (FET) tokens in AFET (taken from MPE) and expiration time.
 
 ##### args:
 
 - `account` (Account): The account object used to send the transaction.
 - `payment_address` (str): The address of the payment recipient.
 - `group_id` (str): The ID of the payment group.
-- `amount` (int): The amount of ASI (FET) tokens in cogs to deposit into the channel.
+- `amount` (int): The amount of ASI (FET) tokens in AFET to deposit into the channel.
 - `expiration` (int): The expiration time of the payment channel in blocks.
 
 ##### returns:
@@ -93,7 +93,7 @@ Opens a payment channel with the specified amount of ASI (FET) tokens in cogs (t
 
 ### `deposit_and_open_channel`
 
-Opens a payment channel with the specified amount of ASI (FET) tokens in cogs (which are previously deposited on MPE) 
+Opens a payment channel with the specified amount of ASI (FET) tokens in AFET (which are previously deposited on MPE) 
 and expiration time. The account must have sufficient allowance to perform the deposit, otherwise the account 
 first approves the transfer.
 
@@ -102,7 +102,7 @@ first approves the transfer.
 - `account` (Account): The account object used to send the transaction.
 - `payment_address` (str): The address of the payment recipient.
 - `group_id` (str): The ID of the payment group.
-- `amount` (int): The amount of ASI (FET) tokens in cogs first for deposit on MPE, then for deposit on the channel.
+- `amount` (int): The amount of ASI (FET) tokens in AFET first for deposit on MPE, then for deposit on the channel.
 - `expiration` (int): The expiration time of the payment channel in blocks.
 
 ##### returns:

--- a/docs/products/DecentralizedAIPlatform/SDK/PythonSDK/Documentation/paidcall-payment-strategy/index.md
+++ b/docs/products/DecentralizedAIPlatform/SDK/PythonSDK/Documentation/paidcall-payment-strategy/index.md
@@ -88,7 +88,7 @@ Checks whether the payment channel has the required amount of funds.
 ##### args:
 
 - `channel` (PaymentChannel): The payment channel to check.
-- `amount` (int): The amount of funds in cogs to check.
+- `amount` (int): The amount of funds in AFET to check.
 
 ##### returns:
 

--- a/docs/products/DecentralizedAIPlatform/SDK/PythonSDK/Documentation/payment-channel-provider/index.md
+++ b/docs/products/DecentralizedAIPlatform/SDK/PythonSDK/Documentation/payment-channel-provider/index.md
@@ -115,13 +115,13 @@ pass it to PaymentChannel instances.
 
 ### `open_channel`
 
-Opens a payment channel with the specified amount of ASI (FET) tokens in cogs (taken from MPE) and expiration time. 
+Opens a payment channel with the specified amount of ASI (FET) tokens in AFET (taken from MPE) and expiration time. 
 And then returns it.
 
 ##### args:
 
 - `account` (Account): The account object used to send the transaction.
-- `amount` (int): The amount of ASI (FET) tokens in cogs to deposit into the channel.
+- `amount` (int): The amount of ASI (FET) tokens in AFET to deposit into the channel.
 - `expiration` (int): The expiration time of the payment channel in blocks.
 - `payment_address` (str): The address of the payment recipient.
 - `group_id` (str): The ID of the payment group.
@@ -134,13 +134,13 @@ pass it to PaymentChannel instances.
 
 ### `deposit_and_open_channel`
 
-Opens a payment channel with the specified amount of ASI (FET) tokens in cogs (which are previously deposited on MPE) 
+Opens a payment channel with the specified amount of ASI (FET) tokens in AFET (which are previously deposited on MPE) 
 and expiration time. And then returns it.
 
 ##### args:
 
 - `account` (Account): The account object used to send the transaction.
-- `amount` (int): The amount of ASI (FET) tokens in cogs to deposit into the channel.
+- `amount` (int): The amount of ASI (FET) tokens in AFET to deposit into the channel.
 - `expiration` (int): The expiration time of the payment channel in blocks.
 - `payment_address` (str): The address of the payment recipient.
 - `group_id` (str): The ID of the payment group.

--- a/docs/products/DecentralizedAIPlatform/SDK/PythonSDK/Documentation/payment-strategy/index.md
+++ b/docs/products/DecentralizedAIPlatform/SDK/PythonSDK/Documentation/payment-strategy/index.md
@@ -42,5 +42,5 @@ Returns the price for calling a service using the provided client service.
 
 ##### returns:
 
-- Price of calling service in cogs. (int)
+- Price of calling service in AFET. (int)
 

--- a/docs/products/DecentralizedAIPlatform/SDK/PythonSDK/Documentation/prepaid-payment-strategy/index.md
+++ b/docs/products/DecentralizedAIPlatform/SDK/PythonSDK/Documentation/prepaid-payment-strategy/index.md
@@ -106,7 +106,7 @@ Checks whether the payment channel has the required amount of funds.
 ##### args:
 
 - `channel` (PaymentChannel): The payment channel to check.
-- `amount` (int): The amount of funds in cogs to check.
+- `amount` (int): The amount of funds in AFET to check.
 
 ##### returns:
 

--- a/docs/products/DecentralizedAIPlatform/SDK/PythonSDK/Documentation/service-client/index.md
+++ b/docs/products/DecentralizedAIPlatform/SDK/PythonSDK/Documentation/service-client/index.md
@@ -231,11 +231,11 @@ is the client for the payment channel state service.
 
 ### `open_channel`
 
-Opens a payment channel with the specified amount of ASI (FET) tokens in cogs and expiration time.
+Opens a payment channel with the specified amount of ASI (FET) tokens in AFET and expiration time.
 
 ##### args:
 
-- `amount` (int): The amount of ASI (FET) tokens in cogs to deposit into the channel.
+- `amount` (int): The amount of ASI (FET) tokens in AFET to deposit into the channel.
 - `expiration` (int): The expiration time of the payment channel in blocks.
 
 ##### returns:
@@ -245,11 +245,11 @@ Opens a payment channel with the specified amount of ASI (FET) tokens in cogs an
 ### `deposit_and_open_channel`
 
 Deposits the specified amount of tokens into the MPE smart contract and opens a payment channel 
-with its amount of ASI (FET) tokens in cogs and expiration time.
+with its amount of ASI (FET) tokens in AFET and expiration time.
 
 ##### args:
 
-- `amount` (int): The amount of ASI (FET) tokens in cogs to deposit into the channel.
+- `amount` (int): The amount of ASI (FET) tokens in AFET to deposit into the channel.
 - `expiration` (int): The expiration time of the payment channel in blocks.
 
 ##### returns:
@@ -258,11 +258,11 @@ with its amount of ASI (FET) tokens in cogs and expiration time.
 
 ### `get_price`
 
-Returns the price in cogs of the service group's pricing.
+Returns the price in AFET of the service group's pricing.
 
 ##### returns:
 
-- The price in cogs of the service group's pricing. (int)
+- The price in AFET of the service group's pricing. (int)
 
 ### `generate_signature`
 

--- a/docs/products/DecentralizedAIPlatform/SDK/PythonSDK/console-app/index.md
+++ b/docs/products/DecentralizedAIPlatform/SDK/PythonSDK/console-app/index.md
@@ -364,7 +364,7 @@ def open_channel():
         if not is_continue:
             return None
 
-    amount = int(input("Enter amount of ASI (FET) tokens in cogs to put into the channel: ").strip())
+    amount = int(input("Enter amount of ASI (FET) tokens in AFET to put into the channel: ").strip())
 
     balance = snet_sdk.account.escrow_balance()
     is_deposit = False

--- a/docs/products/DecentralizedAIPlatform/SDK/PythonSDK/getting-started-guide/index.md
+++ b/docs/products/DecentralizedAIPlatform/SDK/PythonSDK/getting-started-guide/index.md
@@ -195,7 +195,7 @@ managed by the SDK. But anyway you can use them if you want.
 
 #### Open channel with the specified amount of funds and expiration
 
-`open_channel()`[[1]](#1-this-method-uses-a-call-to-a-paid-smart-contract-function) opens a payment channel with the specified amount of FET tokens in cogs and expiration time. 
+`open_channel()`[[1]](#1-this-method-uses-a-call-to-a-paid-smart-contract-function) opens a payment channel with the specified amount of ASI (FET) tokens in AFET and expiration time. 
 Expiration is payment channel's TTL in blocks. When opening a channel, funds are taken from MPE. So they must be 
 pre-deposited on it. For this, you can use the `deposit_to_escrow_account()`[[1]](#1-this-method-uses-a-call-to-a-paid-smart-contract-function) 
 method.
@@ -206,7 +206,7 @@ service_client.open_channel(amount=123456, expiration=33333)
 ```
 
 You can also use the `deposit_and_open_channel()`[[1]](#1-this-method-uses-a-call-to-a-paid-smart-contract-function) 
-method instead. It does the same as the previous one, but first deposits the specified amount of FET tokens in cogs 
+method instead. It does the same as the previous one, but first deposits the specified amount of ASI (FET) tokens in AFET 
 into an MPE.
 
 ```python
@@ -301,8 +301,8 @@ To find out the price of calling a service function, you need to use the `get_pr
 
 ```python
 price = service_client.get_price()
-print(f"The price in cogs for calling the service {service_client.service_id} is {price}")
-# The price in cogs for calling the service Exampleservice is 1
+print(f"The price in AFET for calling the service {service_client.service_id} is {price}")
+# The price in AFET for calling the service Exampleservice is 1
 ```
 
 #### Get the metadata of the service
@@ -322,7 +322,7 @@ print(*service_metadata.get_all_endpoints_for_group(group_name="default_group"),
 # ('service_type', 'grpc')
 # ('model_ipfs_hash', 'QmeyrQkEyba8dd4rc3jrLd5pEwsxHutfH2RvsSaeSMqTtQ')
 # ('mpe_address', '0x7E0aF8988DF45B824b2E0e0A87c6196897744970')
-# ('groups', [{'free_calls': 0, 'free_call_signer_address': '0x7DF35C98f41F3Af0df1dc4c7F7D4C19a71Dd059F', 'daemon_addresses': ['0x0709e9b78756b740ab0c64427f43f8305fd6d1a7'], 'pricing': [{'default': True, 'price_model': 'fixed_price', 'price_in_cogs': 1}], 'endpoints': ['http://node1.naint.tech:62400'], 'group_id': '/mb90Qs8VktxGQmU0uRu0bSlGgqeDlYrKrs+WbsOvOQ=', 'group_name': 'default_group'}])
+# ('groups', [{'free_calls': 0, 'free_call_signer_address': '0x7DF35C98f41F3Af0df1dc4c7F7D4C19a71Dd059F', 'daemon_addresses': ['0x0709e9b78756b740ab0c64427f43f8305fd6d1a7'], 'pricing': [{'default': True, 'price_model': 'fixed_price', 'price_in_afet': 1}], 'endpoints': ['http://node1.naint.tech:62400'], 'group_id': '/mb90Qs8VktxGQmU0uRu0bSlGgqeDlYrKrs+WbsOvOQ=', 'group_name': 'default_group'}])
 # ('service_description', {'url': 'https://ropsten-v2-publisher.singularitynet.io/org', 'short_description': 'Example service', 'description': 'Example service'})
 # ('media', [{'order': 1, 'url': 'https://ropsten-marketplace-service-assets.s3.us-east-1.amazonaws.com/26072b8b6a0e448180f8c0e702ab6d2f/services/d05c62bf9aa84843a195457d98417f4e/assets/20240327124952_asset.jpeg', 'file_type': 'image', 'asset_type': 'hero_image', 'alt_text': ''}])
 # ('contributors', [{'name': 'test', 'email_id': ''}])


### PR DESCRIPTION
- Update token decimals from 8 to 18 in ASI token documentation
- Replace COG/cog/Cogs references with AFET across documentation:
  - CoreConcepts: MPE smart contracts, glossary
  - SDK Documentation: Python SDK (account, mpe-contract, service-client, payment-channel-provider, payment-strategy, prepaid/paidcall strategies, getting-started-guide, console-app)
  - CLI Manual: Client command descriptions
  - Developer Tutorials: OnboardingViaCLI, IntegrationTrainingService, FullGuideOnboarding
- Update price examples: 10^-8 ASI (FET) = 1 COG → 10^-18 ASI (FET) = 1 AFET